### PR TITLE
Fix add_to_inside

### DIFF
--- a/lua/printer/init.lua
+++ b/lua/printer/init.lua
@@ -129,11 +129,11 @@ Printer.setup = function(cfg_user)
     vim.keymap.set("v", keymap, operator_visual, { expr = true, desc = "Operator keymap for printer.nvim" })
   end
 
-  -- check if cfg_user has add_to_text key,
-  -- add_to_text = nill should be valid can't check it just through nill check
+  -- check if cfg_user has add_to_inside key,
+  -- add_to_inside = nill should be valid can't check it just through nill check
   local has_add_to_inside = false
   for key, _ in pairs(cfg_user) do
-    if key == "add_to_text" then
+    if key == 'add_to_inside' then
       has_add_to_inside = true
     end
   end


### PR DESCRIPTION
The `add_to_inside` feature is currently broken because some code (line 136) is checking for `add_to_text`, while other code (line 142) is checking `add_to_inside`. Make this consistent with the docs by using `add_to_inside` everywhere.