### PR TITLE
Ignore the formatoptions setting

### DIFF
--- a/lua/printer/init.lua
+++ b/lua/printer/init.lua
@@ -93,7 +93,8 @@ local function input(text)
     end
 
     if Behavior == "insert_below" then
-      vim.fn.execute("normal! o" .. text_to_insert)
+      vim.fn.append(vim.fn.line("."), text_to_insert)
+      vim.fn.execute("normal! 2==")
     elseif Behavior == "yank" then
       vim.fn.setreg('"', text_to_insert)
     end


### PR DESCRIPTION
when the selected text is inside a comment it inserts commented prints,  
this inserts it uncommented even if formatoptions=c is set and i believe is a more programmatic way to do it